### PR TITLE
Fix the (still incomplete) test for language-independent fields

### DIFF
--- a/archetypes/multilingual/tests/languageindependentfields.txt
+++ b/archetypes/multilingual/tests/languageindependentfields.txt
@@ -63,6 +63,11 @@ Translate the object::
 
     >>> from plone.multilingual.interfaces import ITranslationManager
     >>> manager = ITranslationManager(portal[content_id])
+
+Manually call update on the manager, to ensure that the TG is up to date.
+Note: This should happen via event subscriber outside of tests.
+
+    >>> manager.update()
     >>> manager.add_translation('en')
     >>> obj_en = manager.get_translation('en')
     >>> import transaction; transaction.commit()


### PR DESCRIPTION
The test currently it fails in the set-up, when a translation of a test object is created.
By explicitly calling the update method on the translation manager, we ensure that the
Translation Group gets updated, and this (yet incomplete) test does not fail.
