### PR TITLE
Babelview: use drop-down for languages instead of buttons when there are too many translations

### DIFF
--- a/archetypes/multilingual/skins/archetypesmultilingual/at_babel_edit.cpt
+++ b/archetypes/multilingual/skins/archetypesmultilingual/at_babel_edit.cpt
@@ -96,11 +96,20 @@
                 Available translations for this content
               </h1>
               <div id="trans-selector"
-                   tal:define="languages pamutils/translated_languages;">
+                   tal:define="languages pamutils/translated_languages;
+                   max_nr_of_buttons pamutils/max_nr_of_buttons">
                   <input type="hidden" id="url_translate" value="" tal:attributes="value context/absolute_url"/>
                   <input type="hidden" id="gtanslate_service" value="" tal:attributes="value pamutils/gtenabled"/>
-                  <div class="btn-group">
-                    <tal:block repeat="lang languages">
+                  <div class="btn-group"
+                    tal:define="use_dropdown python:max_nr_of_buttons and max_nr_of_buttons < len(languages)">
+                    <select name="language_selector" tal:condition="use_dropdown">
+                      <option tal:repeat="lang languages"
+                        tal:attributes="value string:${lang/obj/absolute_url}/babel_view;
+                                              selected python:lang['isDefault'] and 'selected' or '';
+                                              id string:selection-${lang/code}"
+                        tal:content="lang/info/native|lang/info/name">Language</option>
+                    </select>
+                    <tal:block repeat="lang languages" condition="not:use_dropdown">
                       <button class="btn"
                               tal:attributes="data-url string:${lang/obj/absolute_url}/babel_view;
                                               class python:lang['isDefault'] and 'btn active' or 'btn';


### PR DESCRIPTION
Follow-up for plone/plone.app.multilingual/pull/37
