### PR TITLE
add __name__ method

### DIFF
--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from Acquisition import aq_parent
 from zope.component.hooks import getSite
 from zope.component import getUtility
@@ -65,6 +66,9 @@ class LanguageIndependentModifier(object):
             if language != content_lang:
                 translations_list_to_process.append(translations[language])
         return translations_list_to_process
+
+    def __name__(self):
+        return 'handler'
 
 handler = LanguageIndependentModifier()
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,12 +7,11 @@ Changelog
 1.2 - 2013-09-24
 ----------------
 
-- Add french translations
-
 - __name__ method is added for preventing bug when you try to go in Components
   tab into ZMI (/manage_components) or when you try to make a snapshot.
   [bsuttor]
-
+  
+- Add french translations
 
 1.0 - 2013-04-16
 ----------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,11 +9,19 @@ Changelog
 
 - Add french translations
 
+- __name__ method is added for preventing bug when you try to go in Components
+  tab into ZMI (/manage_components) or when you try to make a snapshot.
+  [bsuttor]
+
+
 1.0 - 2013-04-16
 ----------------
 
-- Correct js url on portal_factory babel view [ramon]
-- Show selector if num languages is large [pysailor]
+- Correct js url on portal_factory babel view 
+  [ramon]
+
+- Show selector if num languages is large 
+  [pysailor]
 
 1.0rc1 - 2013-01-26
 -------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,13 +4,13 @@ Changelog
 1.3dev - Unreleased
 -------------------
 
-1.2 - 2013-09-24
-----------------
-
 - __name__ method is added for preventing bug when you try to go in Components
   tab into ZMI (/manage_components) or when you try to make a snapshot.
   [bsuttor]
   
+1.2 - 2013-09-24
+----------------
+
 - Add french translations
 
 1.0 - 2013-04-16


### PR DESCRIPTION
Commit message:
-----------------------
\__name__ method is added for preventing bug when you try to go in Components tab into ZMI (/manage_components) or when you try to make a snapshot.

Message:
------------
Hello, 

I make this pull request because of this bug :
https://github.com/plone/plone.app.multilingual/issues/111

It seems GenericSetup utilities needs \__name__ attribute:
https://github.com/zopefoundation/Products.GenericSetup/blob/master/Products/GenericSetup/utils.py#L63

But when I saw the code, I'didn't understand why you/we have a class instead of a def method for a subscriber ? 
And why the subscriber is registred in componentregistry.xml instead of put in zcml ?

(There is same problem on plone.multilingualbehavior : https://github.com/plone/plone.multilingualbehavior/blob/master/plone/multilingualbehavior/subscriber.py)

I'm thinking about this code if we want to change subscriber registration :


`archetypes/multilingual/configure.zcml`

    <subscriber
      for="archetypes.multilingual.interfaces.IArchetypesTranslatable
           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
      handler="archetypes.multilingual.subscriber.handler"
      />


`archetypes/multilingual/subscriber.py`

    # -*- coding: utf-8 -*-
    from zope.component import queryAdapter
    from zope.component import getGlobalSiteManager
    from zope.event import notify
    from zope.lifecycleevent import Attributes
    from zope.lifecycleevent import ObjectModifiedEvent
    from zope.lifecycleevent.interfaces import IObjectModifiedEvent

    from archetypes.multilingual.interfaces import IArchetypesTranslatable

    from plone.multilingual.interfaces import ILanguage
    from plone.multilingual.interfaces import ILanguageIndependentFieldsManager
    from plone.multilingual.interfaces import ITranslationManager


    def handler(context, event):
        stack = []
        canonical = ITranslationManager(context).query_canonical()
        if canonical in stack:
            return
        else:
            stack.append(canonical)

            # Copy over all language independent fields
            translations = get_all_translations(context)
            manager = ILanguageIndependentFieldsManager(context)
            for translation in translations:
                manager.copy_fields(translation)

            schema = context.Schema()
            descriptions = Attributes(schema)
            reindex_translations(translations, descriptions)
            stack.remove(canonical)


    def reindex_translations(translations, descriptions):
        """Once the modifications are done, reindex all translations"""
        for translation in translations:
            translation.reindexObject()
            notify(ObjectModifiedEvent(translation, descriptions))


    def get_all_translations(context):
        """Return all translations excluding the just modified content"""
        translations_list_to_process = []
        content_lang = queryAdapter(context, ILanguage).get_language()
        canonical = ITranslationManager(context)
        translations = canonical.get_translations()

        for language in translations.keys():
            if language != content_lang:
                translations_list_to_process.append(translations[language])
        return translations_list_to_process

    gsm = getGlobalSiteManager()
    gsm.registerHandler(handler, (IArchetypesTranslatable, IObjectModifiedEvent))


