### PR TITLE
Fix translation group on translated objects

### DIFF
--- a/archetypes/multilingual/configure.zcml
+++ b/archetypes/multilingual/configure.zcml
@@ -41,6 +41,11 @@
              zope.lifecycleevent.interfaces.IObjectModifiedEvent"
         handler=".subscriber.handler" />
 
+    <subscriber
+        for="archetypes.multilingual.interfaces.IArchetypesTranslatable
+             Products.Archetypes.interfaces.IObjectInitializedEvent"
+        handler=".subscriber.archetypes_creation_handler"/>
+
     <adapter
         for="archetypes.multilingual.interfaces.IArchetypesTranslatable"
         provides="plone.app.multilingual.interfaces.ITranslationCloner"

--- a/archetypes/multilingual/configure.zcml
+++ b/archetypes/multilingual/configure.zcml
@@ -4,6 +4,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:monkey="http://namespaces.plone.org/monkey"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:cmf="http://namespaces.zope.org/cmf">
 
     <include package="Products.ATContentTypes" />
@@ -44,6 +45,29 @@
     <subscriber
         for="archetypes.multilingual.interfaces.IArchetypesTranslatable
              Products.Archetypes.interfaces.IObjectInitializedEvent"
+        handler=".subscriber.archetypes_creation_handler"/>
+
+    <configure zcml:condition="not-installed zope.container">
+        <subscriber
+            for="archetypes.multilingual.interfaces.IArchetypesTranslatable
+                 zope.app.container.interfaces.IObjectAddedEvent"
+            handler=".subscriber.archetypes_creation_handler"/>
+    </configure>
+
+    <configure zcml:condition="installed zope.container">
+      <subscriber
+            for="archetypes.multilingual.interfaces.IArchetypesTranslatable
+                 zope.container.interfaces.IObjectAddedEvent"
+            handler=".subscriber.archetypes_creation_handler"/>
+    </configure>
+
+    <subscriber
+        for="archetypes.multilingual.interfaces.IArchetypesTranslatable
+             zope.lifecycleevent.interfaces.IObjectCopiedEvent"
+        handler=".subscriber.archetypes_creation_handler"/>
+    <subscriber
+        for="archetypes.multilingual.interfaces.IArchetypesTranslatable
+             zope.lifecycleevent.interfaces.IObjectMovedEvent"
         handler=".subscriber.archetypes_creation_handler"/>
 
     <adapter

--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -67,7 +67,8 @@ class ArchetypesCreationEvent(CreationEvent):
 
     @property
     def has_pam_old_lang_in_form(self):
-        # XXX Need to be improved
+        # Archetypes content types does not have the pam_old_lang field
+        # XXX Need to be improved to have a different behavior for add and edit
         return False
 
     @property

--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -3,6 +3,7 @@ from archetypes.multilingual.interfaces import IArchetypesTranslatable
 from plone.app.multilingual.interfaces import ILanguage
 from plone.app.multilingual.interfaces import ILanguageIndependentFieldsManager
 from plone.app.multilingual.interfaces import ITranslationManager
+from plone.app.multilingual.subscriber import CreationEvent
 from zope.component import queryAdapter
 from zope.event import notify
 from zope.lifecycleevent import Attributes
@@ -58,3 +59,14 @@ class LanguageIndependentModifier(object):
         return translations_list_to_process
 
 handler = LanguageIndependentModifier()
+
+
+class ArchetypesCreationEvent(CreationEvent):
+
+    @property
+    def has_pam_old_lang_in_form(self):
+        # XXX Need to be improved
+        return False
+
+
+archetypes_creation_handler = ArchetypesCreationEvent()

--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -10,6 +10,7 @@ from zope.event import notify
 from zope.lifecycleevent import Attributes
 from zope.lifecycleevent import ObjectModifiedEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.lifecycleevent.interfaces import IObjectRemovedEvent
 
 
 class LanguageIndependentModifier(object):
@@ -71,7 +72,8 @@ class ArchetypesCreationEvent(CreationEvent):
 
     @property
     def is_translatable(self):
-        return not IDexterityContent.providedBy(self.obj)
+        return (not IObjectRemovedEvent.providedBy(self.event)
+                and not IDexterityContent.providedBy(self.obj))
 
 
 archetypes_creation_handler = ArchetypesCreationEvent()

--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -4,6 +4,7 @@ from plone.app.multilingual.interfaces import ILanguage
 from plone.app.multilingual.interfaces import ILanguageIndependentFieldsManager
 from plone.app.multilingual.interfaces import ITranslationManager
 from plone.app.multilingual.subscriber import CreationEvent
+from plone.dexterity.interfaces import IDexterityContent
 from zope.component import queryAdapter
 from zope.event import notify
 from zope.lifecycleevent import Attributes
@@ -67,6 +68,10 @@ class ArchetypesCreationEvent(CreationEvent):
     def has_pam_old_lang_in_form(self):
         # XXX Need to be improved
         return False
+
+    @property
+    def is_translatable(self):
+        return not IDexterityContent.providedBy(self.obj)
 
 
 archetypes_creation_handler = ArchetypesCreationEvent()

--- a/archetypes/multilingual/tests/test_factory.py
+++ b/archetypes/multilingual/tests/test_factory.py
@@ -68,3 +68,6 @@ class TestFactory(unittest.TestCase):
         self.assertIn('Mijn document', self.browser.contents)
         translations = ITranslationManager(doc_nl).get_translations()
         self.assertTrue("fr" in translations.keys(), 'fr language should be in translations')
+
+        translations = ITranslationManager(doc_fr).get_translations()
+        self.assertTrue("nl" in translations.keys(), 'nl language should be in translations')

--- a/archetypes/multilingual/tests/test_factory.py
+++ b/archetypes/multilingual/tests/test_factory.py
@@ -1,0 +1,70 @@
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+from Products.CMFCore.utils import getToolByName
+from plone.app.multilingual.interfaces import ILanguage
+
+from plone.app.multilingual.interfaces import ITranslationManager
+from plone.testing.z2 import Browser
+from archetypes.multilingual.testing import \
+    ARCHETYPESMULTILINGUAL_FUNCTIONAL_TESTING
+import transaction
+import unittest2 as unittest
+from plone.app.multilingual.browser.setup import SetupMultilingualSite
+
+auth_header = 'Basic {0:s}:{1:s}'.format(TEST_USER_NAME, TEST_USER_PASSWORD)
+
+
+class TestFactory(unittest.TestCase):
+
+    layer = ARCHETYPESMULTILINGUAL_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+
+        # Define available languages
+        language_tool = getToolByName(self.portal, 'portal_languages')
+        language_tool.addSupportedLanguage('fr')
+        language_tool.addSupportedLanguage('nl')
+
+        # Enable request negotiator
+        language_tool.use_request_negotiation = True
+
+        # Setup language root folders
+        setup_tool = SetupMultilingualSite()
+        setup_tool.setupSite(self.portal)
+        self.lrf_fr = self.portal.fr
+        self.lrf_nl = self.portal.nl
+        self.browser = Browser(self.layer['app'])
+
+    def test_factory_creation(self):
+        self.browser.addHeader('Authorization', auth_header)
+
+        doc_fr_id = self.lrf_fr.invokeFactory('Document', 'fr-document')
+        doc_fr = self.lrf_fr[doc_fr_id]
+        # ILanguage(folder).set_language('fr')
+        transaction.commit()
+
+        self.browser.open('{0:s}/@@create_translation?language=nl'.format(
+            doc_fr.absolute_url()))
+        self.assertIn(
+            'id="multilingual-add-form-is-translation"', self.browser.contents)
+
+    def test_link_between_documents(self):
+        self.browser.addHeader('Authorization', auth_header)
+
+        doc_fr_id = self.lrf_fr.invokeFactory('Document', 'fr-document')
+        doc_fr = self.lrf_fr[doc_fr_id]
+        # ILanguage(folder).set_language('fr')
+        transaction.commit()
+
+        self.browser.open('{0:s}/@@create_translation?language=nl'.format(
+            doc_fr.absolute_url()))
+        self.browser.getControl(name="title").value = "nl-document"
+        self.browser.getControl(name="text").value = "Mijn document"
+        self.browser.getControl(name="form.button.save").click()
+        doc_nl = self.lrf_nl['nl-document']
+        self.assertEqual(ILanguage(doc_nl).get_language(), 'nl')
+        self.assertIn('Mijn document', self.browser.contents)
+        translations = ITranslationManager(doc_nl).get_translations()
+        self.assertTrue("fr" in translations.keys(), 'fr language should be in translations')


### PR DESCRIPTION
Currently the translation group on the newly translated objects does not match the translation group of the original object.

This PR fix that by adding a subscriber for the event `Products.Archetypes.interfaces.IObjectInitializedEvent` and by ignoring the check on `form.widgets.pam_old_lang` from request since this field does not exist for Archetypes content types.

This is related to the PR plone/plone.app.multilingual#156

cc @bsuttor