### PR TITLE
[Needs adopting] [2.x] Only react to events if product is installed

### DIFF
--- a/archetypes/multilingual/browser/configure.zcml
+++ b/archetypes/multilingual/browser/configure.zcml
@@ -14,7 +14,7 @@
           manager="plone.app.layout.viewlets.interfaces.IAboveContent"
           class=".viewlets.addFormATIsATranslationViewlet"
           template="templates/add-form-is-translation.pt"
-          layer="plone.app.multilingual.interfaces.IPloneAppMultilingualInstalled"
+          layer="archetypes.multilingual.interfaces.IArchetypesMultilingualInstalled"
           permission="zope.Public"
           />
 

--- a/archetypes/multilingual/browser/viewlets.py
+++ b/archetypes/multilingual/browser/viewlets.py
@@ -5,11 +5,10 @@ from plone.app.layout.viewlets.common import ViewletBase
 from plone.app.multilingual.interfaces import ILanguage
 from plone.app.multilingual.interfaces import ITranslatable
 from plone.app.multilingual.browser.viewlets import AddFormIsATranslationViewlet
-from archetypes.multilingual import logger
 
 
 class addFormATIsATranslationViewlet(AddFormIsATranslationViewlet):
-    """ Notice the user that this add form is a translation
+    """ Notify the user that this add form is a translation
     """
     available = False
 

--- a/archetypes/multilingual/interfaces.py
+++ b/archetypes/multilingual/interfaces.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
 from plone.app.multilingual.interfaces import ITranslatable
+from zope.interface import Interface
+
+
+class IArchetypesMultilingualInstalled(Interface):
+    """ Marker interface """
 
 
 class IArchetypesTranslatable(ITranslatable):

--- a/archetypes/multilingual/profile.zcml
+++ b/archetypes/multilingual/profile.zcml
@@ -11,4 +11,12 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:registerProfile
+      name="uninstall"
+      title="Remove Archetypes Multilingual Support"
+      directory="profiles/uninstall"
+      description="Removes the components of Archetypes Multilingual."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
 </configure>

--- a/archetypes/multilingual/profiles/default/browserlayer.xml
+++ b/archetypes/multilingual/profiles/default/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<layers>
+  <layer
+      name="archetypes.multilingual"
+      interface="archetypes.multilingual.interfaces.IArchetypesMultilingualInstalled"/>
+</layers>

--- a/archetypes/multilingual/profiles/uninstall/browserlayer.xml
+++ b/archetypes/multilingual/profiles/uninstall/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+  <layer
+      name="archetypes.multilingual"
+      interface="archetypes.multilingual.interfaces.IArchetypesMultilingualInstalled"
+      remove="True"
+</layers>

--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_parent
+from archetypes.multilingual.interfaces import IArchetypesMultilingualInstalled
 from archetypes.multilingual.interfaces import IArchetypesTranslatable
 from plone.app.multilingual.interfaces import ILanguage
 from plone.app.multilingual.interfaces import ILanguageIndependentFieldsManager
@@ -94,6 +95,10 @@ def archetypes_creation_handler(obj, event):
     - IObjectAddedEvent
     - IObjectCopiedEvent
     """
+    # if not installed
+    if (not IArchetypesMultilingualInstalled.providedBy(obj.REQUEST)):
+        return
+    
     # if not translatable
     if (not IObjectRemovedEvent.providedBy(event)
        and IDexterityContent.providedBy(obj)):


### PR DESCRIPTION
I've tried to make changes here to fix the [failing plone.app.multilingual 2.x tests](https://github.com/plone/plone.app.multilingual/pull/204).  However, I'm not using archetypes myself & I've got this far & am now admittedly stuck as to how to fix things here & I am wary of breaking anything I'm not using.

Anyone want to take over?

My theory is that certain elements of archetypes.multillingual activate when the product isn't installed, affecting the p.a.m tests - hence the adding of the browser layer & attempt to test for it in the recently added event subscriber.
