### PR TITLE
Remove transaction commit

### DIFF
--- a/archetypes/multilingual/tests/languageindependentfields.txt
+++ b/archetypes/multilingual/tests/languageindependentfields.txt
@@ -70,5 +70,3 @@ Note: This should happen via event subscriber outside of tests.
     >>> manager.update()
     >>> manager.add_translation('en')
     >>> obj_en = manager.get_translation('en')
-    >>> import transaction; transaction.commit()
-


### PR DESCRIPTION
Its use on an integration test is forbidden, due to test isolation breakage.

@bloodbare these last lines are actually not testing anything, are they needed?