### PR TITLE
[2.x] Fix translation group handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,14 @@
 *.mo
 *.py[c|o]
 /.Python
+/.installed.cfg
+/.mr.developer.cfg
 /bin
 /build/*
+/develop-eggs/
 /dist/*
 /include
 /lib
+/parts/
+/src/
 Paste*

--- a/archetypes/multilingual/browser/add.py
+++ b/archetypes/multilingual/browser/add.py
@@ -24,7 +24,7 @@ class MultilingualATAddForm(BrowserView):
         self.request.translation_info
 
     def _get_original_object(self):
-        uid = self.request.get('type', None)
+        uid = self.request.get('uid', None)
 
         if uid is None:
             raise Exception('Original object not specified')

--- a/archetypes/multilingual/browser/add.py
+++ b/archetypes/multilingual/browser/add.py
@@ -43,9 +43,8 @@ class MultilingualATAddForm(BrowserView):
 
         if type_name in self.context.portal_factory.getFactoryTypes():
             new_url = 'portal_factory/' + type_name + '/' + id + '/at_babel_edit'
-            new_url = '%s?tg=%s&source_language=%s' % (new_url,
-                                                       self.tg,
-                                                       self.source_language)
+            new_url = '%s?persistent_tg=%s&persistent_source_language=%s' % (
+                new_url, self.tg, self.source_language)
             return self.request.response.redirect(new_url)
             # state.set(status='factory',
             #           next_action='redirect_to:string:%s' % new_url)

--- a/archetypes/multilingual/browser/viewlets.py
+++ b/archetypes/multilingual/browser/viewlets.py
@@ -5,11 +5,10 @@ from plone.app.layout.viewlets.common import ViewletBase
 from plone.app.multilingual.interfaces import ILanguage
 from plone.app.multilingual.interfaces import ITranslatable
 from plone.app.multilingual.browser.viewlets import AddFormIsATranslationViewlet
-from archetypes.multilingual import logger
 
 
 class addFormATIsATranslationViewlet(AddFormIsATranslationViewlet):
-    """ Notice the user that this add form is a translation
+    """ Notify the user that this add form is a translation
     """
     available = False
 

--- a/archetypes/multilingual/language.py
+++ b/archetypes/multilingual/language.py
@@ -16,11 +16,20 @@ class ATLanguage(object):
 
     def get_language(self):
         language = self.context.Language()
-        portal_factory = getToolByName(self, 'portal_factory', None)
-        if portal_factory is not None and portal_factory.isTemporary(self):
-            navroot = getNavigationRootObject(self.context, getSite())
+        portal_factory = getToolByName(self.context, 'portal_factory', None)
+        if portal_factory is not None and portal_factory.isTemporary(self.context):
+            # This should probably be fixed in plone.app.layout getNavigationRootObject
+            # Right now navigation root of a temporary object is Plone site due to acquisition
+            # https://github.com/plone/plone.app.layout/issues/57
+            context = self.context.aq_parent.aq_parent.aq_parent
+            navroot = getNavigationRootObject(context, getSite())
             if navroot != self.context:
-                language = ILanguage(navroot).get_language()
+                try:
+                    lang_info = ILanguage(navroot)
+                    language = lang_info.get_language()
+                except TypeError:
+                    # I can still reach this point when translating items outside language folders
+                    language = None
         if not language:
             language = LANGUAGE_INDEPENDENT
         return language
@@ -29,3 +38,4 @@ class ATLanguage(object):
         # Override the setLanguage method imposed by LP
         # and access to the direct mutator of the object
         self.context.getField('language').set(self.context, language)
+        self.context.reindexObject(idxs=['Language'])

--- a/archetypes/multilingual/language.py
+++ b/archetypes/multilingual/language.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from Products.CMFCore.utils import getToolByName
 from plone.app.layout.navigation.root import getNavigationRootObject
 from plone.app.multilingual.interfaces import ILanguage
@@ -21,7 +23,8 @@ class ATLanguage(object):
             # This should probably be fixed in plone.app.layout getNavigationRootObject
             # Right now navigation root of a temporary object is Plone site due to acquisition
             # https://github.com/plone/plone.app.layout/issues/57
-            context = self.context.aq_parent.aq_parent.aq_parent
+            # We can manually construct the correct `context`, though...
+            context = aq_parent(aq_parent(aq_parent(aq_inner(self.context))))
             navroot = getNavigationRootObject(context, getSite())
             if navroot != self.context:
                 try:

--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -127,8 +127,8 @@ def archetypes_creation_handler(obj, event):
 
 
 def get_translation_info(request):
-    info = {'tg': request.get('tg'),
-            'source_language': request.get('source_language')}
+    info = {'tg': request.get('persistent_tg'),
+            'source_language': request.get('persistent_source_language')}
     if not info.get('tg') or not info.get('source_language'):
         raise AttributeError
     return info

--- a/archetypes/multilingual/testing.py
+++ b/archetypes/multilingual/testing.py
@@ -21,16 +21,16 @@ class ArchetypesMultilingualLayer(PloneSandboxLayer):
             self[key] = value
 
     def setUpZope(self, app, configurationContext):
-        # load ZCML
+        import Products.ATContentTypes
+        self.loadZCML(package=Products.ATContentTypes)
+
+        z2.installProduct(app, 'Products.Archetypes')
+        z2.installProduct(app, 'Products.ATContentTypes')
+
         import archetypes.multilingual
-        import archetypes.testcase
 
         xmlconfig.file('testing.zcml', archetypes.multilingual,
                        context=configurationContext)
-        xmlconfig.file('configure.zcml', archetypes.testcase,
-                       context=configurationContext)
-
-        z2.installProduct(app, 'archetypes.testcase')
 
         # Support sessionstorage in tests
         app.REQUEST['SESSION'] = self.Session()
@@ -42,9 +42,12 @@ class ArchetypesMultilingualLayer(PloneSandboxLayer):
         ztc.utils.setupCoreSessions(app)
 
     def setUpPloneSite(self, portal):
-        # install into the Plone site
+        # install Products.ATContentTypes manually if profile is available
+        # (this is only needed for Plone >= 5)
+        profiles = [x['id'] for x in portal.portal_setup.listProfileInfo()]
+        if 'Products.ATContentTypes:default' in profiles:
+            applyProfile(portal, 'Products.ATContentTypes:default')
         applyProfile(portal, 'archetypes.multilingual:default')
-        applyProfile(portal, 'archetypes.testcase:default')
 
 ARCHETYPESMULTILINGUAL_FIXTURE = ArchetypesMultilingualLayer()
 

--- a/archetypes/multilingual/tests/multilingual.txt
+++ b/archetypes/multilingual/tests/multilingual.txt
@@ -4,8 +4,6 @@ testing the multilingualsupport
 creating some sample-content::
 
     >>> portal = layer['portal']
-    >>> language_tool = portal.portal_languages
-    >>> language_tool.start_neutral = 0
     >>> from plone.app.testing import TEST_USER_ID, setRoles
     >>> setRoles(portal, TEST_USER_ID, ['Manager'])
     >>> content_id = portal.invokeFactory(type_name="Document", id='monkey_sample')

--- a/archetypes/multilingual/tests/test_language_adapter.py
+++ b/archetypes/multilingual/tests/test_language_adapter.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import transaction
+import unittest2 as unittest
+from Products.CMFCore.utils import getToolByName
+from plone.app.multilingual.interfaces import ILanguage
+from plone.app.multilingual.interfaces import LANGUAGE_INDEPENDENT
+from archetypes.multilingual.testing import \
+    ARCHETYPESMULTILINGUAL_INTEGRATION_TESTING
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.layout.navigation.interfaces import INavigationRoot
+from plone.testing.z2 import Browser
+from zope.interface import alsoProvides
+
+
+auth_header = 'Basic {0:s}:{1:s}'.format(TEST_USER_NAME,
+                                         TEST_USER_PASSWORD)
+
+
+class TestATILanguage(unittest.TestCase):
+
+    layer = ARCHETYPESMULTILINGUAL_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.browser = Browser(self.layer['app'])
+        self.browser.handleErrors = False
+        self.portal_url = self.portal.absolute_url()
+        self.ltool = getToolByName(self.portal, 'portal_languages')
+        self.ltool.addSupportedLanguage('ca')
+        self.ltool.addSupportedLanguage('es')
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+
+    def test_real_content_with_lang(self):
+        portal = self.portal
+        portal.invokeFactory(type_name='Document', id='doc')
+        ILanguage(portal.doc).set_language('de')
+        self.assertEqual(ILanguage(portal.doc).get_language(), 'de')
+
+    def test_real_content_no_lang(self):
+        portal = self.portal
+        portal.invokeFactory(type_name='Document', id='doc')
+        self.assertEqual(ILanguage(portal.doc).get_language(),
+                         LANGUAGE_INDEPENDENT)
+
+    def test_real_content_in_folder(self):
+        portal = self.portal
+        self.portal.invokeFactory(type_name='Folder', id='folder')
+        ILanguage(portal.folder).set_language('de')
+        portal.folder.invokeFactory(type_name='Document', id='doc')
+        self.assertEqual(ILanguage(portal.folder.doc).get_language(), 'de')
+
+    def test_temp_content_root_folder(self):
+        portal = self.portal
+        self.portal.invokeFactory(type_name='Folder', id='folder1')
+        self.browser.addHeader('Authorization', auth_header)
+        ILanguage(portal.folder1).set_language('de')
+        alsoProvides(portal.folder1, INavigationRoot)
+        transaction.commit()
+        self.browser.open('{0:s}/createObject?type_name=Document'.format(
+            portal.folder1.absolute_url()))
+        self.browser.getControl(name="title").value = "doc"
+        self.browser.getControl(name="form.button.save").click()
+        self.assertEqual(ILanguage(portal.folder1.doc).get_language(), 'de')

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,9 @@
+[buildout]
+extends = https://raw.github.com/collective/buildout.plonetest/master/test-4.x.cfg
+extensions = mr.developer
+package-name = archetypes.multilingual
+package-extras = [test]
+auto-checkout = *
+
+[sources]
+plone.app.multilingual = git https://github.com/witsch/plone.app.multilingual.git branch=2.x

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- The ``ILanguage`` implementation for Archetypes was broken. This close #13.
+  [keul]
+
 - Add tests when content is added with portal_factory (old way)
   [bsuttor]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - The ``ILanguage`` implementation for Archetypes was broken. This close #13.
-  [keul]
+  [keul, frisi]
 
 - Add tests when content is added with portal_factory (old way)
   [bsuttor]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Remove archetypes.testcase test dependency.
+  [timo]
+
 - The ``ILanguage`` implementation for Archetypes was broken. This close #13.
   [keul, frisi]
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'setuptools',
         'Products.ATContentTypes',
-        'plone.app.multilingual',
+        'plone.app.multilingual >= 2.0.4dev, < 3.0',
         'collective.monkeypatcher',
         'plone.api',
         # -*- Extra requirements: -*-

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'test': [
             'plone.app.testing',
             'plone.app.multilingual[test]',
-            'archetypes.testcase'
         ]
     },
     entry_points="""


### PR DESCRIPTION
This is a follow-up on #17 and attempts to fix the missing translation links (and thereby also the [corresponding test](https://github.com/plone/archetypes.multilingual/pull/17/files#diff-7ece0cbd035a967af946ea65f94699cfR58).  Doing so it should allow to close #18 and #13.

The issue here was that the values for "translation group" and "source language" didn't make it through the archetypes edit form (`at_babel_edit.cpt`) so the portal factory instance created when POSTing that form was missing them (because the responsible [subscriber bailed out early](https://github.com/plone/archetypes.multilingual/blob/2.x/archetypes/multilingual/subscriber.py#L120)).

This could have been fixed in Archetypes' [`edit_macros.pt`](https://github.com/plone/Products.Archetypes/blob/1.9.x/Products/Archetypes/skins/archetypes/edit_macros.pt) like so:
```diff
diff --git a/Products/Archetypes/skins/archetypes/edit_macros.pt b/Products/Archetypes/skins/archetypes/edit_macros.pt
index 369c5c6e..b4417859 100644
--- a/Products/Archetypes/skins/archetypes/edit_macros.pt
+++ b/Products/Archetypes/skins/archetypes/edit_macros.pt
@@ -206,6 +206,9 @@
                    tal:attributes="value python:(last_referer and '%s/%s' % (context.absolute_url(), template.id) not in last_referer) and last_referer or (context.getParentNode() and context.getParentNode().absolute_url())"
                    />
 
+            <input type="hidden" name="tg" tal:attributes="value request/form/tg | nothing" />
+            <input type="hidden" name="source_language" tal:attributes="value request/form/source_language | nothing" />
+
             <metal:block define-slot="buttons"
                    tal:define="fieldset_index python:fieldset in fieldsets and fieldsets.index(fieldset);
                                n_fieldsets python:len(fieldsets)">
```
but luckily the form also supports [persistent form variables](https://github.com/plone/Products.Archetypes/blob/1.9.x/Products/Archetypes/skins/archetypes/edit_macros.pt#L186).  This is a bit crude, imho, but works without the need to adjust further packages.

However, the UUID of the source object [needs to be passed (again)](https://github.com/plone/plone.app.multilingual/commit/c7d96f1f4fdfe82b3d6e202bd9aadb284ceb32f0) so the [add form](https://github.com/plone/archetypes.multilingual/blob/150534322eea2488d78d69d6655d59a01e88e65a/archetypes/multilingual/browser/add.py#L27) can determine the required values (after [passing them via the session has been removed](https://github.com/plone/plone.app.multilingual/pull/154)).

In any case, both the `archetypes.multilingual` and `plone.app.multilingual` tests pass again (or still, respectively) with this fix and we can successfully translate content again in our [portal](https://www.pik-potsdam.de) (using Plone 4.3.18 and the `2.x` branches of these packages).

PS: As [mentioned in #19](https://github.com/plone/archetypes.multilingual/pull/19#issuecomment-189345377) the test isolation issues in `p.a.multilingual` have already been fixed (there), and since the remaining fix (171747ef0c59b35f302b587a89320fe5ab85a766) is contained in this pull request, #19 looks like it might also be okay to close if this gets merged… 🙂