### PR TITLE
Make sure translations can be added to "private" target folders.

### DIFF
--- a/archetypes/multilingual/testing.py
+++ b/archetypes/multilingual/testing.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from Products.CMFCore.utils import getToolByName
 from OFS.Folder import Folder
 from Testing import ZopeTestCase as ztc
 from plone.app.testing import FunctionalTesting
@@ -48,6 +49,10 @@ class ArchetypesMultilingualLayer(PloneSandboxLayer):
         if 'Products.ATContentTypes:default' in profiles:
             applyProfile(portal, 'Products.ATContentTypes:default')
         applyProfile(portal, 'archetypes.multilingual:default')
+        # set default workflow
+        wftool = getToolByName(portal, 'portal_workflow')
+        wftool.setDefaultChain('simple_publication_workflow')
+
 
 ARCHETYPESMULTILINGUAL_FIXTURE = ArchetypesMultilingualLayer()
 

--- a/archetypes/multilingual/tests/test_factory.py
+++ b/archetypes/multilingual/tests/test_factory.py
@@ -55,6 +55,21 @@ class TestFactory(unittest.TestCase):
         self.assertIn(
             'id="babel-edit"', self.browser.contents)
 
+    def test_factory_creation_on_private_folder(self):
+        self.browser.addHeader('Authorization', auth_header)
+
+        doc_fr_id = self.lrf_fr.invokeFactory('Document', 'fr-document')
+        doc_fr = self.lrf_fr[doc_fr_id]
+
+        # the target folder is "private"
+        wftool = getToolByName(self.portal, 'portal_workflow')
+        wftool.doActionFor(self.lrf_nl, 'retract')
+        transaction.commit()
+
+        self.browser.open('{0:s}/@@create_translation?language=nl'.format(doc_fr.absolute_url()))
+        self.assertIn(
+            'id="babel-edit"', self.browser.contents)
+
     def test_link_between_documents(self):
         self.browser.addHeader('Authorization', auth_header)
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
+- Add test for fix regarding "Insufficient Privileges" errors.
+  See https://github.com/plone/plone.app.multilingual/pull/351
+  [witsch]
+
 - Remove archetypes.testcase test dependency.
   [timo]
 


### PR DESCRIPTION
This tests a fix in [`plone.app.multilingual`](https://github.com/plone/plone.app.multilingual/blob/df5a42f921477b3c6cdffa689b8f10f853bf7a01/src/plone/app/multilingual/browser/add.py), where traversal causes an "Insufficient Privileges" error when trying to add a new translation to a folder for which anonymous users have no access permissions. See https://github.com/plone/plone.app.multilingual/pull/351 for more information.