### PR TITLE
Fix export of components by adding a __name__ property to the handler. [master]

### DIFF
--- a/archetypes/multilingual/subscriber.py
+++ b/archetypes/multilingual/subscriber.py
@@ -57,4 +57,9 @@ class LanguageIndependentModifier(object):
                 translations_list_to_process.append(translations[language])
         return translations_list_to_process
 
+    @property
+    def __name__(self):
+        return "handler"
+
+
 handler = LanguageIndependentModifier()

--- a/news/27.bugfix
+++ b/news/27.bugfix
@@ -1,0 +1,2 @@
+Fix export of components by adding a ``__name__`` property to the handler.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/archetypes.multilingual/issues/27

See also https://github.com/plone/plone.multilingualbehavior/pull/10