### PR TITLE
Corrected typos in xml files

### DIFF
--- a/archetypes/multilingual/profiles/default/componentregistry.xml
+++ b/archetypes/multilingual/profiles/default/componentregistry.xml
@@ -11,15 +11,6 @@
       provides="plone.app.multilingual.interfaces.ILanguageIndependentFieldsManager"
       factory="archetypes.multilingual.utils.LanguageIndependentFieldsManager"
     />
-    <adapter
-        for="archetypes.multilingual.interfaces.IArchetypesTranslatable"
-        provides="plone.app.multilingual.interfaces.ITranslationCloner"
-        factory="archetypes.multilingual.cloner.Cloner"/>
-
-    <adapter
-        for="archetypes.multilingual.interfaces.IArchetypesTranslatable"
-        provides="plone.app.multilingual.interfaces.ILanguageIndependentFieldsManager"
-        factory="archetypes.multilingual.utils.LanguageIndependentFieldsManager"/>
   </adapters>
   <subscribers>
     <subscriber

--- a/archetypes/multilingual/profiles/uninstall/componentregistry.xml
+++ b/archetypes/multilingual/profiles/uninstall/componentregistry.xml
@@ -13,19 +13,6 @@
       factory="archetypes.multilingual.utils.LanguageIndependentFieldsManager"
       remove="True"
     />
-    <adapter
-        for="archetypes.multilingual.interfaces.IArchetypesTranslatable"
-        provides="plone.app.multilingual.interfaces.ITranslationCloner"
-        factory=".cloner.Cloner"
-        remove="True"
-    />
-
-    <adapter
-        for="archetypes.multilingual.interfaces.IArchetypesTranslatable"
-        provides="plone.app.multilingual.interfaces.ILanguageIndependentFieldsManager"
-        factory=".utils.LanguageIndependentFieldsManager"
-        remove="True"
-    />
   </adapters>
   <subscribers>
     <subscriber


### PR DESCRIPTION
Hello,

there seem to be redundant sections in the `componentregistry.xml` files, both for install and uninstall.

Moreover, using a relative path (factory=".cloner.Cloner") seems to prevent Plone from uninstalling the product.

Laurent.